### PR TITLE
fix: reordered tags in publications and projects-and-consultancy sect…

### DIFF
--- a/app/[locale]/faculty-and-staff/utils.tsx
+++ b/app/[locale]/faculty-and-staff/utils.tsx
@@ -466,6 +466,19 @@ async function FacultySectionComponent({
     new Set(result.filter((item) => item.tag).map((item) => item.tag))
   ) as string[];
 
+  // Custom order for tags
+const tagOrder = ['journal', 'conference', 'book', 'book-chapter', 'project', 'consultancy'];
+
+// Sort uniqueTags by custom order, others go last
+uniqueTags.sort((a, b) => {
+  const indexA = tagOrder.indexOf(a);
+  const indexB = tagOrder.indexOf(b);
+  if (indexA === -1 && indexB === -1) return a.localeCompare(b);
+  if (indexA === -1) return 1;
+  if (indexB === -1) return -1;
+  return indexA - indexB;
+});
+
   const tagStyle =
     `
             .tag-filter:has(#filter-all:checked) ~ .rounded-2xl ul li {

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -344,6 +344,7 @@ const text: Translations = {
       trademark: 'Trademark',
       project: 'Project',
       consultancy: 'Consultancy',
+      'book chapter': 'Book Chapter',
     },
     tabs: {
       qualifications: 'Education Qualifications',

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -353,6 +353,7 @@ const text: Translations = {
       copyright: 'कॉपीराइट',
       project: 'प्रोजेक्ट्स',
       consultancy: 'परामर्श',
+      'book chapter': 'पुस्तक अध्याय',
     },
     tabs: {
       qualifications: 'शैक्षिक योग्यता',

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -214,6 +214,7 @@ export interface Translations {
       copyright: string;
       project: string;
       consultancy: string;
+      'book chapter': string;
     };
     tabs: {
       qualifications: string;


### PR DESCRIPTION
This pull request introduces a custom ordering for publication tags in the faculty and staff section and adds translation support for the "book chapter" tag in both English and Hindi. The main changes are as follows:

**Faculty and Staff Section Improvements:**

* Added a custom sort order for publication tags so that tags like `journal`, `conference`, `book`, `book-chapter`, `project`, and `consultancy` appear first, with any other tags sorted alphabetically at the end. (`app/[locale]/faculty-and-staff/utils.tsx`) ([app/[locale]/faculty-and-staff/utils.tsxR469-R481](diffhunk://#diff-3e362b10e143377150343a08121115b31eeefe1081b2d3cdc3bb5551eaec6b4dR469-R481))

**Internationalization Updates:**

* Added the "book chapter" label to the English translations under publication types. (`i18n/en.ts`)
* Added the "book chapter" label to the Hindi translations under publication types. (`i18n/hi.ts`)
* Updated the `Translations` interface to include the "book chapter" key under publication types. (`i18n/translations.ts`)…ion also capitalized book chapter