### PR TITLE
fix: fixed overflow on small screens when hindi is selected

### DIFF
--- a/app/[locale]/institute/cells/scst/page.tsx
+++ b/app/[locale]/institute/cells/scst/page.tsx
@@ -30,8 +30,8 @@ export default async function SCST({
           backgroundImage: `linear-gradient(to bottom, rgba(0,0,0,0.5), rgba(0,0,0,0.3)), url('${getS3Url()}/training-and-placement/header.jpg')`,
         }}
       >
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
-          <h1 className="mx-2 my-auto text-3xl text-[#FFFFFF] md:text-2xl lg:text-3xl xl:text-4xl font-serif font-normal whitespace-nowrap">
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-center w-[90%] max-w-5xl">
+          <h1 className="mx-2 my-auto text-3xl text-[#FFFFFF]  lg:text-3xl xl:text-4xl font-serif font-normal ">
             {text.Institute.cells.scst.title}
           </h1>
         </div>


### PR DESCRIPTION
#401 
This pull request makes a minor update to the layout of the SCST page header. The main change is an adjustment to the styling of the header's title container to improve its responsiveness and appearance.

- UI/Styling Improvements:
  * The title container in the SCST page header (`page.tsx`) now has a width of 90% and a maximum width (`max-w-5xl`), which helps the header text scale better on different screen sizes. Additionally, the `whitespace-nowrap` class was removed from the title to allow text wrapping, and the `md:text-2xl` class was removed for consistency in font sizing across breakpoints. ([app/[locale]/institute/cells/scst/page.tsxL33-R34](diffhunk://#diff-19c9706882ffe3c5011d10c9fc1e574aa3f0c8095b33184bddde8ec8abf2ba6cL33-R34))