### PR TITLE
fix: handle empty coursesToMajors in Courses component

### DIFF
--- a/app/[locale]/academics/curricula/page.tsx
+++ b/app/[locale]/academics/curricula/page.tsx
@@ -90,8 +90,16 @@ const Courses = async ({ page }: { page: number }) => {
 
   console.log(courses);
 
-  return courses.map(({ code, coursesToMajors, title }) =>
-    coursesToMajors.map(
+  return courses.map(({ code, coursesToMajors, title }) => {
+    if (coursesToMajors.length === 0) {
+      return (
+        <TableRow key={code}>
+          <TableCell>{code}</TableCell>
+          <TableCell>{title}</TableCell>
+        </TableRow>
+      );
+    }
+    return coursesToMajors.map(
       ({ lectureCredits, practicalCredits, tutorialCredits, major }, index) => (
         <TableRow key={index}>
           <TableCell>{code}</TableCell>
@@ -113,5 +121,5 @@ const Courses = async ({ page }: { page: number }) => {
         </TableRow>
       )
     )
-  );
+});
 };


### PR DESCRIPTION
This pull request updates the rendering logic for the courses table in `app/[locale]/academics/curricula/page.tsx`. The main improvement is ensuring that courses with no associated majors are still displayed in the table, preventing them from being omitted.

Rendering improvements:

* Courses that have no entries in `coursesToMajors` are now rendered as a single row with just their `code` and `title`, ensuring all courses are shown in the table. ([app/[locale]/academics/curricula/page.tsxL93-R102](diffhunk://#diff-f28e90cdfc2124ecddf73b3a9d4522b6270d42112fa9b8a81c67656ed7722c86L93-R102))
* The mapping logic for rendering table rows has been refactored to handle the case where `coursesToMajors` is empty, improving code readability and correctness. ([app/[locale]/academics/curricula/page.tsxL116-R124](diffhunk://#diff-f28e90cdfc2124ecddf73b3a9d4522b6270d42112fa9b8a81c67656ed7722c86L116-R124))