### PR TITLE
feat: Image url logic changed

### DIFF
--- a/app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsx
+++ b/app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsx
@@ -9,11 +9,13 @@ import { Button } from '~/components/buttons';
 import { env } from '~/lib/env/client';
 import { toast } from '~/lib/hooks';
 import { uploadMedia } from '~/server/actions/media-upload';
+import { updatePersonProfileImage } from '~/server/actions/faculty-profile';
 
 interface FacultyPhotoUploadProps {
   facultyName: string;
   employeeId: string;
   facultyId: number;
+  currentImageUrl?: string | null;
   onPhotoUploaded?: (url: string) => void;
 }
 
@@ -33,15 +35,24 @@ export function FacultyPhotoUpload({
   facultyName,
   employeeId,
   facultyId,
+  currentImageUrl,
   onPhotoUploaded,
 }: FacultyPhotoUploadProps) {
   const [isUploading, setIsUploading] = useState(false);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [isCheckingPhoto, setIsCheckingPhoto] = useState(true);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(
+    currentImageUrl ?? null
+  );
+  const [isCheckingPhoto, setIsCheckingPhoto] = useState(!currentImageUrl);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Check for existing photo on mount by trying different extensions
+  // Check for existing photo on mount by trying different extensions (only if no currentImageUrl)
   useEffect(() => {
+    if (currentImageUrl) {
+      setPreviewUrl(currentImageUrl);
+      setIsCheckingPhoto(false);
+      return;
+    }
+
     const checkExistingPhoto = async () => {
       const photoUrls = getPhotoUrls(employeeId, facultyId);
 
@@ -60,7 +71,7 @@ export function FacultyPhotoUpload({
     };
 
     void checkExistingPhoto();
-  }, [employeeId, facultyId]);
+  }, [employeeId, facultyId, currentImageUrl]);
 
   const handleClick = () => {
     fileInputRef.current?.click();
@@ -107,13 +118,25 @@ export function FacultyPhotoUpload({
       });
 
       if (result.success && result.url) {
-        toast({
-          title: 'Success',
-          description: 'Profile photo updated successfully.',
-          variant: 'success',
-        });
-        setPreviewUrl(result.url);
-        onPhotoUploaded?.(result.url);
+        // Save the image URL to the persons table
+        const dbResult = await updatePersonProfileImage(result.url);
+
+        if (dbResult.success) {
+          toast({
+            title: 'Success',
+            description: 'Profile photo updated successfully.',
+            variant: 'success',
+          });
+          setPreviewUrl(result.url);
+          onPhotoUploaded?.(result.url);
+        } else {
+          toast({
+            title: 'Warning',
+            description:
+              'Photo uploaded but failed to save to profile. Please try again.',
+            variant: 'error',
+          });
+        }
       } else {
         toast({
           title: 'Error',

--- a/app/[locale]/@modals/(.)profile/edit/page.tsx
+++ b/app/[locale]/@modals/(.)profile/edit/page.tsx
@@ -69,6 +69,7 @@ export default async function Page({
               telephone: true,
               alternateCountryCode: true,
               alternateTelephone: true,
+              img: true,
             },
           },
         },
@@ -79,6 +80,7 @@ export default async function Page({
           id: result.id,
           employeeId: result.employeeId,
           name: result.person.name,
+          img: result.person.img,
           officeAddress: result.officeAddress,
           scopusId: result.scopusId ?? undefined,
           linkedInId: result.linkedInId ?? undefined,
@@ -112,6 +114,7 @@ export default async function Page({
               facultyName={personalDetails.name}
               employeeId={personalDetails.employeeId}
               facultyId={personalDetails.id}
+              currentImageUrl={personalDetails.img}
             />
           </div>
 

--- a/app/[locale]/faculty-and-staff/faculty-image.tsx
+++ b/app/[locale]/faculty-and-staff/faculty-image.tsx
@@ -15,6 +15,8 @@ interface FacultyImageProps {
   height?: number;
   fill?: boolean;
   sizes?: string;
+  /** The image URL from the persons.img field */
+  imageUrl?: string | null;
 }
 
 const PHOTO_EXTENSIONS = ['jpg', 'png', 'webp'] as const;
@@ -29,11 +31,18 @@ export function FacultyImage({
   height,
   fill,
   sizes,
+  imageUrl,
 }: FacultyImageProps) {
   const [currentExtIndex, setCurrentExtIndex] = useState(0);
   const [useFallback, setUseFallback] = useState(false);
 
   const handleError = () => {
+    // If we have an imageUrl from DB and it fails, go to fallback
+    if (imageUrl) {
+      setUseFallback(true);
+      return;
+    }
+
     if (currentExtIndex < PHOTO_EXTENSIONS.length - 1) {
       // Try next extension
       setCurrentExtIndex((prev) => prev + 1);
@@ -43,9 +52,12 @@ export function FacultyImage({
     }
   };
 
+  // Prioritize imageUrl from DB, then try legacy path, then fallback
   const imageSrc = useFallback
     ? FALLBACK_IMAGE
-    : `${env.NEXT_PUBLIC_AWS_S3_URL}/faculty-and-staff/${employeeId}/${facultyId}.${PHOTO_EXTENSIONS[currentExtIndex]}`;
+    : imageUrl
+      ? imageUrl
+      : `${env.NEXT_PUBLIC_AWS_S3_URL}/faculty-and-staff/${employeeId}/${facultyId}.${PHOTO_EXTENSIONS[currentExtIndex]}`;
 
   if (fill) {
     return (

--- a/app/[locale]/faculty-and-staff/page.tsx
+++ b/app/[locale]/faculty-and-staff/page.tsx
@@ -374,7 +374,11 @@ const FacultyList = async ({
       ? (faculty, { inArray }) =>
           inArray(faculty.departmentId, selectedDepartmentIds)
       : undefined,
-    with: { person: { columns: { email: true, name: true, telephone: true } } },
+    with: {
+      person: {
+        columns: { email: true, name: true, telephone: true, img: true },
+      },
+    },
   });
 
   const filteredFaculty = faculty.filter(({ person }) =>
@@ -409,6 +413,7 @@ const FacultyList = async ({
               employeeId={faculty.employeeId}
               facultyId={faculty.id}
               alt={faculty.person.name}
+              imageUrl={faculty.person.img}
               width={176}
               height={176}
               className="my-auto size-32 rounded lg:size-36 xl:size-40 2xl:size-44"

--- a/app/[locale]/faculty-and-staff/utils.tsx
+++ b/app/[locale]/faculty-and-staff/utils.tsx
@@ -125,6 +125,7 @@ export async function FacultyOrStaffComponent({
           countryCode: true,
           alternateTelephone: true,
           alternateCountryCode: true,
+          img: true,
         },
       },
       department: {
@@ -243,6 +244,7 @@ export async function FacultyOrStaffComponent({
             employeeId={facultyDescription.employeeId}
             facultyId={facultyDescription.id}
             alt={facultyDescription.person.name}
+            imageUrl={facultyDescription.person.img}
             width={200}
             height={200}
             className="absolute right-0 top-0 z-10 mr-3 size-32 translate-y-[-50%] rounded-full border-[1rem] border-background sm:mr-6 sm:size-40 lg:mr-8 lg:size-48 xl:hidden"
@@ -287,6 +289,7 @@ export async function FacultyOrStaffComponent({
             employeeId={facultyDescription.employeeId}
             facultyId={facultyDescription.id}
             alt={facultyDescription.person.name}
+            imageUrl={facultyDescription.person.img}
             width={200}
             height={200}
             className="absolute z-10 size-48 translate-x-[-50%] translate-y-[-50%] rounded-full border-[16px] border-background"

--- a/app/[locale]/header.tsx
+++ b/app/[locale]/header.tsx
@@ -386,23 +386,14 @@ const AuthAction = async ({
   const session = await getServerAuthSession();
 
   if (session) {
-    let id = '';
-    if (session.person.type === 'faculty') {
-      id = (await db.query.faculty.findFirst({
-        columns: { employeeId: true },
-        where: (faculty, { eq }) => eq(faculty.id, session.person.id),
-      }))!.employeeId;
-    } else if (session.person.type === 'staff') {
-      id = (await db.query.staff.findFirst({
-        columns: { employeeId: true },
-        where: (staff, { eq }) => eq(staff.id, session.person.id),
-      }))!.employeeId;
-    } else if (session.person.type === 'student') {
-      id = (await db.query.students.findFirst({
-        columns: { rollNumber: true },
-        where: (student, { eq }) => eq(student.id, session.person.id),
-      }))!.rollNumber;
-    }
+    // Fetch the person's image from the database
+    const person = await db.query.persons.findFirst({
+      columns: { img: true },
+      where: (persons, { eq }) => eq(persons.id, session.person.id),
+    });
+
+    const profileImage =
+      person?.img ?? session.user.image ?? 'fallback/user-image.jpg';
 
     return mobile ? (
       <Button
@@ -414,9 +405,7 @@ const AuthAction = async ({
           <ProfileImage
             alt={text.alt}
             className={className}
-            // FIXME: Remove session.user.image once
-            // everyone's image is fed to the bucket
-            src={session.user.image ?? `persons/${id}/image.png`}
+            src={profileImage}
           />
           {text.view}
         </Link>
@@ -425,10 +414,8 @@ const AuthAction = async ({
       <ProfileImage
         alt={text.alt}
         className={className}
-        // FIXME: Remove session.user.image once
-        // everyone's image is fed to the bucket
         href={`/${locale}/profile`}
-        src={session.user.image ?? `persons/${id}/image.png`}
+        src={profileImage}
       />
     );
   } else {

--- a/app/[locale]/search/cards.tsx
+++ b/app/[locale]/search/cards.tsx
@@ -215,7 +215,7 @@ const FacultyCard = ({
     <article className="rounded-lg bg-shade-light p-3 sm:grid-cols-8 md:grid md:px-4">
       <header className="col-span-3 flex items-center gap-2">
         <Image
-          src={`persons/${document.employeeId}/image.png`}
+          src={document.img ?? 'fallback/user-image.jpg'}
           alt={document.name}
           width={60}
           height={60}
@@ -293,7 +293,7 @@ const StaffCard = ({
     <article className="rounded-lg bg-shade-light p-3 sm:grid-cols-8 md:grid md:px-4">
       <header className="col-span-3 flex items-center gap-2">
         <Image
-          src={`persons/${document.employeeId}/image.png`}
+          src={document.img ?? 'fallback/user-image.jpg'}
           alt={document.name}
           width={60}
           height={60}

--- a/server/actions/faculty-profile.ts
+++ b/server/actions/faculty-profile.ts
@@ -241,3 +241,23 @@ export async function editFacultyProfilePersonalDetails(
     return { success: false, message: 'Failed to update personal details' };
   }
 }
+
+export async function updatePersonProfileImage(imageUrl: string) {
+  const session = await getServerAuthSession();
+  if (!session || !session.person.id) {
+    return { success: false, message: 'Not authorized' };
+  }
+
+  try {
+    await db
+      .update(persons)
+      .set({ img: imageUrl })
+      .where(eq(persons.id, session.person.id));
+
+    revalidatePath('/profile');
+    return { success: true, message: 'Profile image updated successfully' };
+  } catch (error) {
+    console.error('Error updating profile image:', error);
+    return { success: false, message: 'Failed to update profile image' };
+  }
+}

--- a/server/db/schema/persons.schema.ts
+++ b/server/db/schema/persons.schema.ts
@@ -16,6 +16,7 @@ export const persons = pgTable(
 
     sex: t.varchar({ enum: ['M', 'F', 'O'] }).notNull(),
     dateOfBirth: t.date({ mode: 'date' }),
+    img: t.varchar(),
     roleId: t.smallint().references(() => roles.id),
     type: t.varchar({ enum: ['faculty', 'staff', 'student'] }).notNull(),
     isActive: t.boolean().default(true).notNull(),

--- a/server/typesense/collections/faculty.ts
+++ b/server/typesense/collections/faculty.ts
@@ -8,6 +8,7 @@ export const facultySchema: CollectionCreateSchema = {
     { name: 'designation', type: 'string', index: false, optional: true },
     { name: 'email', type: 'string' },
     { name: 'employeeId', type: 'string', index: false, optional: true },
+    { name: 'img', type: 'string', index: false, optional: true },
     { name: 'name', type: 'string' },
     { name: 'officeAddress', type: 'string', index: false, optional: true },
     { name: 'telephone', type: 'string' },
@@ -19,13 +20,16 @@ export const populateFaculty = async () => {
     await db.query.faculty.findMany({
       columns: { designation: true, employeeId: true, officeAddress: true },
       with: {
-        person: { columns: { email: true, name: true, telephone: true } },
+        person: {
+          columns: { email: true, name: true, telephone: true, img: true },
+        },
       },
     })
   ).map(({ designation, employeeId, officeAddress, person }) => ({
     designation,
     email: person.email,
     employeeId,
+    img: person.img,
     name: person.name,
     officeAddress,
     telephone: person.telephone,
@@ -45,7 +49,6 @@ export const isFacultyDocument = (
     typeof document.email === 'string' &&
     typeof document.employeeId === 'string' &&
     typeof document.name === 'string' &&
-    typeof document.officeAddress === 'string' &&
     typeof document.telephone === 'string'
   );
 };

--- a/server/typesense/collections/staff.ts
+++ b/server/typesense/collections/staff.ts
@@ -8,6 +8,7 @@ export const staffSchema: CollectionCreateSchema = {
     { name: 'designation', type: 'string', index: false, optional: true },
     { name: 'email', type: 'string' },
     { name: 'employeeId', type: 'string', index: false, optional: true },
+    { name: 'img', type: 'string', index: false, optional: true },
     { name: 'name', type: 'string' },
     { name: 'telephone', type: 'string' },
   ],
@@ -18,13 +19,16 @@ export const populateStaff = async () => {
     await db.query.staff.findMany({
       columns: { designation: true, employeeId: true },
       with: {
-        person: { columns: { email: true, name: true, telephone: true } },
+        person: {
+          columns: { email: true, name: true, telephone: true, img: true },
+        },
       },
     })
   ).map(({ designation, employeeId, person }) => ({
     designation,
     email: person.email,
     employeeId,
+    img: person.img,
     name: person.name,
     telephone: person.telephone,
   }));


### PR DESCRIPTION
This pull request implements full support for storing, displaying, and updating user profile images for faculty and staff. It introduces a new `img` field to the `persons` table, updates the upload flow to save image URLs in the database, and ensures that profile images are consistently used across the application, including in search, profile, and listing components. The Typesense search collections and population scripts are also updated to include the new image field.

**Database and API changes:**

* Added an `img` (image URL) field to the `persons` table schema to store profile image URLs.
* Implemented the `updatePersonProfileImage` server action to update a person's profile image in the database and trigger revalidation.

**Profile image upload and display:**

* Updated the faculty photo upload component to accept and display the current image, and to save the uploaded image URL to the database. ([app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxR12-R18](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72R12-R18), [app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxR38-R55](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72R38-R55), [app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxL63-R74](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72L63-R74), [app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxR121-R139](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72R121-R139), [app/[locale]/@modals/(.)profile/edit/page.tsxR72](diffhunk://#diff-e73212c94224fb2541821a5e5cdf5880f9ecace5d712ec5cd8dff6e590ded805R72), [app/[locale]/@modals/(.)profile/edit/page.tsxR83](diffhunk://#diff-e73212c94224fb2541821a5e5cdf5880f9ecace5d712ec5cd8dff6e590ded805R83), [app/[locale]/@modals/(.)profile/edit/page.tsxR117](diffhunk://#diff-e73212c94224fb2541821a5e5cdf5880f9ecace5d712ec5cd8dff6e590ded805R117))
* Enhanced the `FacultyImage` component to prioritize the database image URL, then fallback to legacy paths or a placeholder if needed. ([app/[locale]/faculty-and-staff/faculty-image.tsxR18-R19](diffhunk://#diff-f3054df127f38ef9044a3b238e2c892fffc15bbda73792eaedfe36286ea35c2fR18-R19), [app/[locale]/faculty-and-staff/faculty-image.tsxR34-R45](diffhunk://#diff-f3054df127f38ef9044a3b238e2c892fffc15bbda73792eaedfe36286ea35c2fR34-R45), [app/[locale]/faculty-and-staff/faculty-image.tsxR55-R59](diffhunk://#diff-f3054df127f38ef9044a3b238e2c892fffc15bbda73792eaedfe36286ea35c2fR55-R59))
* Updated the faculty/staff listing and detail components to use the new `img` field for profile images. ([app/[locale]/faculty-and-staff/page.tsxL377-R381](diffhunk://#diff-73d9b8e5183a03609e638663514db195677d4e964b2ba2898d7ad4aa250d81d6L377-R381), [app/[locale]/faculty-and-staff/page.tsxR416](diffhunk://#diff-73d9b8e5183a03609e638663514db195677d4e964b2ba2898d7ad4aa250d81d6R416), [app/[locale]/faculty-and-staff/utils.tsxR128](diffhunk://#diff-3e362b10e143377150343a08121115b31eeefe1081b2d3cdc3bb5551eaec6b4dR128), [app/[locale]/faculty-and-staff/utils.tsxR247](diffhunk://#diff-3e362b10e143377150343a08121115b31eeefe1081b2d3cdc3bb5551eaec6b4dR247), [app/[locale]/faculty-and-staff/utils.tsxR292](diffhunk://#diff-3e362b10e143377150343a08121115b31eeefe1081b2d3cdc3bb5551eaec6b4dR292))

**Search and header integration:**

* Modified search card rendering to use the `img` field for faculty and staff images, with a fallback if not present. ([app/[locale]/search/cards.tsxL218-R218](diffhunk://#diff-a1bf1e6421b8f7db98af617d93ab8477ad1d28a03876f953a55897f0f2ed7eafL218-R218), [app/[locale]/search/cards.tsxL296-R296](diffhunk://#diff-a1bf1e6421b8f7db98af617d93ab8477ad1d28a03876f953a55897f0f2ed7eafL296-R296))
* Updated the authenticated user section in the header to fetch and display the user's profile image from the database. ([app/[locale]/header.tsxL389-R396](diffhunk://#diff-05aeabaff5d1ec0d925bc6519f8dcf6cdc4f94efcf74117ecca3fbbd77eb7777L389-R396), [app/[locale]/header.tsxL417-R408](diffhunk://#diff-05aeabaff5d1ec0d925bc6519f8dcf6cdc4f94efcf74117ecca3fbbd77eb7777L417-R408), [app/[locale]/header.tsxL428-R418](diffhunk://#diff-05aeabaff5d1ec0d925bc6519f8dcf6cdc4f94efcf74117ecca3fbbd77eb7777L428-R418))

**Typesense search collection updates:**

* Added the `img` field to the Typesense `faculty` and `staff` schemas and population scripts, ensuring search results include profile images. [[1]](diffhunk://#diff-c1462ef951f294dc2fba2c4f2e74aaa6eb664ac275887693e67be19ec4998be5R11) [[2]](diffhunk://#diff-c1462ef951f294dc2fba2c4f2e74aaa6eb664ac275887693e67be19ec4998be5L22-R32) [[3]](diffhunk://#diff-c1462ef951f294dc2fba2c4f2e74aaa6eb664ac275887693e67be19ec4998be5L48) [[4]](diffhunk://#diff-3d8eb5594a0483b1e248b500882721ebdcb0e2b005c95f03b3cf7fbb5829d804R11) [[5]](diffhunk://#diff-3d8eb5594a0483b1e248b500882721ebdcb0e2b005c95f03b3cf7fbb5829d804L21-R31)This pull request implements support for storing, updating, and displaying user profile images (specifically for faculty and staff) by introducing an `img` field to the `persons` table and propagating its use throughout the application. The changes ensure that profile images are fetched from and saved to the database, fallback images are used when necessary, and the new field is indexed in search schemas.

**Database and Backend Enhancements:**

- Added a new `img` field to the `persons` table schema to store the profile image URL.
- Implemented the `updatePersonProfileImage` backend action to update the profile image for the currently authenticated user.

**Profile Image Upload and Editing:**

- Updated the faculty photo upload component to accept and display the current profile image, and to save the uploaded image URL to the database. ([app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxR12-R18](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72R12-R18), [app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxR38-R55](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72R38-R55), [app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxL63-R74](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72L63-R74), [app/[locale]/@modals/(.)profile/edit/faculty-photo-upload.tsxR121-R139](diffhunk://#diff-7866be717a5ec66dbf321ab271194ff475030422db1cdcfc38b03472f9189f72R121-R139))
- Modified the profile edit page to fetch and pass the `img` field to the photo upload component. ([app/[locale]/@modals/(.)profile/edit/page.tsxR72](diffhunk://#diff-e73212c94224fb2541821a5e5cdf5880f9ecace5d712ec5cd8dff6e590ded805R72), [app/[locale]/@modals/(.)profile/edit/page.tsxR83](diffhunk://#diff-e73212c94224fb2541821a5e5cdf5880f9ecace5d712ec5cd8dff6e590ded805R83), [app/[locale]/@modals/(.)profile/edit/page.tsxR117](diffhunk://#diff-e73212c94224fb2541821a5e5cdf5880f9ecace5d712ec5cd8dff6e590ded805R117))

**Frontend Usage and Display:**

- Updated the `FacultyImage` component and its consumers to prioritize displaying the image from the database, falling back to legacy paths or a default image as needed. ([app/[locale]/faculty-and-staff/faculty-image.tsxR18-R19](diffhunk://#diff-f3054df127f38ef9044a3b238e2c892fffc15bbda73792eaedfe36286ea35c2fR18-R19), [app/[locale]/faculty-and-staff/faculty-image.tsxR34-R45](diffhunk://#diff-f3054df127f38ef9044a3b238e2c892fffc15bbda73792eaedfe36286ea35c2fR34-R45), [app/[locale]/faculty-and-staff/faculty-image.tsxR55-R59](diffhunk://#diff-f3054df127f38ef9044a3b238e2c892fffc15bbda73792eaedfe36286ea35c2fR55-R59), [app/[locale]/faculty-and-staff/page.tsxL377-R381](diffhunk://#diff-73d9b8e5183a03609e638663514db195677d4e964b2ba2898d7ad4aa250d81d6L377-R381), [app/[locale]/faculty-and-staff/page.tsxR416](diffhunk://#diff-73d9b8e5183a03609e638663514db195677d4e964b2ba2898d7ad4aa250d81d6R416), [app/[locale]/faculty-and-staff/utils.tsxR128](diffhunk://#diff-3e362b10e143377150343a08121115b31eeefe1081b2d3cdc3bb5551eaec6b4dR128), [app/[locale]/faculty-and-staff/utils.tsxR247](diffhunk://#diff-3e362b10e143377150343a08121115b31eeefe1081b2d3cdc3bb5551eaec6b4dR247), [app/[locale]/faculty-and-staff/utils.tsxR292](diffhunk://#diff-3e362b10e143377150343a08121115b31eeefe1081b2d3cdc3bb5551eaec6b4dR292))
- Updated the authentication header and profile image rendering to use the new `img` field, falling back to the previous image or a default if not set. ([app/[locale]/header.tsxL389-R396](diffhunk://#diff-05aeabaff5d1ec0d925bc6519f8dcf6cdc4f94efcf74117ecca3fbbd77eb7777L389-R396), [app/[locale]/header.tsxL417-R408](diffhunk://#diff-05aeabaff5d1ec0d925bc6519f8dcf6cdc4f94efcf74117ecca3fbbd77eb7777L417-R408), [app/[locale]/header.tsxL428-R418](diffhunk://#diff-05aeabaff5d1ec0d925bc6519f8dcf6cdc4f94efcf74117ecca3fbbd77eb7777L428-R418))
- Modified faculty and staff search cards to use the new `img` field for profile images. ([app/[locale]/search/cards.tsxL218-R218](diffhunk://#diff-a1bf1e6421b8f7db98af617d93ab8477ad1d28a03876f953a55897f0f2ed7eafL218-R218), [app/[locale]/search/cards.tsxL296-R296](diffhunk://#diff-a1bf1e6421b8f7db98af617d93ab8477ad1d28a03876f953a55897f0f2ed7eafL296-R296))

**Search Indexing and Typesense Integration:**

- Added the `img` field to the Typesense search schemas and population logic for both faculty and staff, ensuring profile images are indexed and available in search results. [[1]](diffhunk://#diff-c1462ef951f294dc2fba2c4f2e74aaa6eb664ac275887693e67be19ec4998be5R11) [[2]](diffhunk://#diff-c1462ef951f294dc2fba2c4f2e74aaa6eb664ac275887693e67be19ec4998be5L22-R32) [[3]](diffhunk://#diff-c1462ef951f294dc2fba2c4f2e74aaa6eb664ac275887693e67be19ec4998be5L48) [[4]](diffhunk://#diff-3d8eb5594a0483b1e248b500882721ebdcb0e2b005c95f03b3cf7fbb5829d804R11) [[5]](diffhunk://#diff-3d8eb5594a0483b1e248b500882721ebdcb0e2b005c95f03b3cf7fbb5829d804L21-R31)