### PR TITLE
fix: Resolved a conflict that Soumil Jain didn't care even after mentioning a day before he left cllg for home on 13th Feb

### DIFF
--- a/app/[locale]/student-activities/student-council/page.tsx
+++ b/app/[locale]/student-activities/student-council/page.tsx
@@ -1,0 +1,49 @@
+import NotificationsPanel from '~/components/notifications/notifications-panel';
+import Heading from '~/components/heading';
+import ImageHeader from '~/components/image-header';
+import GenericTable from '~/components/ui/generic-table';
+import { getTranslations } from '~/i18n/translations';
+
+export default async function StudentCouncil({
+  params: { locale },
+}: {
+  params: { locale: string };
+}) {
+  const text = await getTranslations(locale);
+
+  return (
+    <>
+      <ImageHeader
+        title={text.StudentCouncil.title}
+        src="student-activities/thought-lab/welcome-bk-shivani.jpeg"
+      />
+
+      <section className="container">
+        {/* Main Title with dual elephants */}
+        <Heading
+          glyphDirection="dual"
+          heading="h3"
+          text={text.StudentCouncil.title.toUpperCase()}
+        />
+
+        {/* About Description */}
+        <p className="mb-6">{text.ThoughtLab.about}</p>
+        <section className="container my-10" id="notifications">
+          <Heading
+            glyphDirection="ltr"
+            heading="h3"
+            href="#notifications"
+            id="notifications"
+            text={text.Notifications.title.toUpperCase()}
+          />
+          <NotificationsPanel
+            locale={locale}
+            category="scoe"
+            showViewAll={true}
+            viewAllHref={`/${locale}/notifications?category=miscellaneous`}
+          />
+        </section>
+      </section>
+    </>
+  );
+}

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -28,8 +28,10 @@ import {
   instituteEn,
   loginEn,
   mainEn,
+  nccEn,
   notFoundEn,
   notificationsEn,
+  nssEn,
   otherOfficersPageEn,
   patentsAndTechnologiesEn,
   profileEn,
@@ -43,12 +45,11 @@ import {
   sectionsEn,
   statusEn,
   studentActivitiesEn,
+  studentCouncilEn,
   tendersEn,
   thoughtLabEn,
   trainingAndPlacementEn,
   websiteContributorsEn,
-  nccEn,
-  nssEn,
 } from './translate';
 
 const text: Translations = {
@@ -89,6 +90,7 @@ const text: Translations = {
   Status: statusEn,
   PatentsAndTechnologies: patentsAndTechnologiesEn,
   StudentActivities: studentActivitiesEn,
+  StudentCouncil: studentCouncilEn,
   Tenders: tendersEn,
   DirectorMessage: directorMessageEn,
   Research: researchEn,

--- a/i18n/hi.ts
+++ b/i18n/hi.ts
@@ -28,8 +28,10 @@ import {
   instituteHi,
   loginHi,
   mainHi,
+  nccHi,
   notFoundHi,
   notificationsHi,
+  nssHi,
   otherOfficersPageHi,
   patentsAndTechnologiesHi,
   profileHi,
@@ -43,12 +45,11 @@ import {
   sectionsHi,
   statusHi,
   studentActivitiesHi,
+  studentCouncilHi,
   tendersHi,
   thoughtLabHi,
   trainingAndPlacementHi,
   websiteContributorsHi,
-  nccHi,
-  nssHi,
 } from './translate';
 
 const text: Translations = {
@@ -89,6 +90,7 @@ const text: Translations = {
   Status: statusHi,
   PatentsAndTechnologies: patentsAndTechnologiesHi,
   StudentActivities: studentActivitiesHi,
+  StudentCouncil: studentCouncilHi,
   Tenders: tendersHi,
   DirectorMessage: directorMessageHi,
   otherOfficersPage: otherOfficersPageHi,

--- a/i18n/translate/index.ts
+++ b/i18n/translate/index.ts
@@ -47,3 +47,4 @@ export * from './training-and-placement';
 export * from './tenders';
 export * from './ncc';
 export * from './nss';
+export * from './student-council';

--- a/i18n/translate/student-council.ts
+++ b/i18n/translate/student-council.ts
@@ -1,0 +1,73 @@
+// Student council translations
+
+export interface StudentCouncilTranslations {
+  title: string;
+  headings: {
+    clubs: string;
+    council: string;
+    events: string;
+    thoughtLab: string;
+    nss: string;
+    ncc: string;
+  };
+  sections: {
+    clubs: { title: string; more: string };
+    council: { title: string; more: string };
+    events: { title: string; more: string };
+    thoughtLab: { title: string; more: string };
+    nss: { title: string; more: string };
+    ncc: { title: string; more: string };
+  };
+}
+
+export const studentCouncilEn: StudentCouncilTranslations = {
+  title: 'Student Council',
+  headings: {
+    clubs: 'Clubs',
+    council: 'Student Council',
+    events: 'Events',
+    thoughtLab: 'Thought Lab',
+    nss: 'NSS',
+    ncc: 'NCC',
+  },
+  sections: {
+    clubs: { title: 'Clubs', more: 'Explore all clubs' },
+    council: {
+      title: 'STUDENT COUNCIL',
+      more: 'Explore all student council activities',
+    },
+    events: { title: 'EVENTS', more: 'Explore all events' },
+    thoughtLab: {
+      title: 'THOUGHT LAB',
+      more: 'Explore all thought lab activities',
+    },
+    nss: { title: 'NSS', more: 'Explore all NSS activities' },
+    ncc: { title: 'NCC', more: 'Explore all NCC activities' },
+  },
+};
+
+export const studentCouncilHi: StudentCouncilTranslations = {
+  title: 'छात्र परिषद',
+  headings: {
+    clubs: 'संघठनें',
+    council: 'छात्र परिषद',
+    events: 'आयोजनाएँ',
+    thoughtLab: 'विचार प्रयोगशाला',
+    nss: 'एनएसएस',
+    ncc: 'एनसीसी',
+  },
+  sections: {
+    clubs: { title: 'संघठनें', more: 'सभी संघठनो को तलाशें' },
+    council: {
+      title: 'छात्र परिषद',
+      more: 'सभी छात्र परिषद गतिविधियों को तलाशें',
+    },
+    events: { title: 'आयोजनाएँ', more: 'सभी आयोजनों को तलाशें' },
+    thoughtLab: {
+      title: 'विचार प्रयोगशाला',
+      more: 'सभी विचार प्रयोगशाला गतिविधियों को तलाशें',
+    },
+    nss: { title: 'एनएसएस', more: 'सभी एनएसएस गतिविधियों को तलाशें' },
+    ncc: { title: 'एनसीसी', more: 'सभी एनसीसी गतिविधियों को तलाशें' },
+  },
+};

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -28,8 +28,10 @@ import type {
   InstituteTranslations,
   LoginTranslations,
   MainTranslations,
+  NCCTranslations,
   NotFoundTranslations,
   NotificationsTranslations,
+  NSSTranslations,
   OtherOfficersPageTranslations,
   PatentsAndTechnologiesTranslations,
   ProfileTranslations,
@@ -43,12 +45,11 @@ import type {
   SectionTranslations,
   StatusTranslations,
   StudentActivitiesTranslations,
+  StudentCouncilTranslations,
   TendersTranslations,
   ThoughtLabTranslations,
   TrainingAndPlacementTranslations,
   WebsiteContributorsTranslations,
-  NCCTranslations,
-  NSSTranslations,
 } from './translate';
 
 export async function getTranslations(locale: string): Promise<Translations> {
@@ -90,6 +91,7 @@ export type {
   SectionsTranslations,
   StatusTranslations,
   StudentActivitiesTranslations,
+  StudentCouncilTranslations,
   TendersTranslations,
   WebsiteContributorsTranslations,
   FacultyAndStaffTranslations,
@@ -142,6 +144,7 @@ export interface Translations {
   Sections: SectionsTranslations;
   Status: StatusTranslations;
   StudentActivities: StudentActivitiesTranslations;
+  StudentCouncil: StudentCouncilTranslations;
   Tenders: TendersTranslations;
   WebsiteContributors: WebsiteContributorsTranslations;
   FacultyAndStaff: FacultyAndStaffTranslations;


### PR DESCRIPTION
This pull request introduces a new Student Council page with full internationalization (i18n) support in both English and Hindi. It adds translation resources, updates the translation infrastructure to include the new section, and implements the page UI with localized content and notifications.

**Key changes:**

### Student Council Page Implementation
* Added a new `student-council` page under student activities, featuring an image header, localized headings, description, and a notifications panel that displays relevant updates. (`app/[locale]/student-activities/student-council/page.tsx`) ([app/[locale]/student-activities/student-council/page.tsxR1-R49](diffhunk://#diff-cd47252245bb14ab7701942c4573653764da67ec688f5d0646ee59c04e339703R1-R49))

### Internationalization (i18n) Support
* Introduced new translation files for the Student Council section in both English and Hindi, including all necessary strings for titles, headings, and sections. (`i18n/translate/student-council.ts`)
* Updated the translation index and type definitions to export and recognize `student-council` translations. (`i18n/translate/index.ts`, `i18n/translations.ts`) [[1]](diffhunk://#diff-80d9d3eb70115dcba5007d8d1dd42dc47785c965d56e566d102076ed38a47f9eR50) [[2]](diffhunk://#diff-f021560af3d5a0f14642131f53f3141ab31d57c62b232272a5a097673e427d49R31-R34) [[3]](diffhunk://#diff-f021560af3d5a0f14642131f53f3141ab31d57c62b232272a5a097673e427d49R48-L51) [[4]](diffhunk://#diff-f021560af3d5a0f14642131f53f3141ab31d57c62b232272a5a097673e427d49R94) [[5]](diffhunk://#diff-f021560af3d5a0f14642131f53f3141ab31d57c62b232272a5a097673e427d49R147)

### Translation Mapping Updates
* Registered the new Student Council translations in both English and Hindi translation files, ensuring the section is available in both languages. (`i18n/en.ts`, `i18n/hi.ts`) [[1]](diffhunk://#diff-8ee4c65eaaf735c33bd37bf76d2a87fb76d02b7928096cc26db6364694988ceeR31-R34) [[2]](diffhunk://#diff-8ee4c65eaaf735c33bd37bf76d2a87fb76d02b7928096cc26db6364694988ceeR48-L51) [[3]](diffhunk://#diff-8ee4c65eaaf735c33bd37bf76d2a87fb76d02b7928096cc26db6364694988ceeR93) [[4]](diffhunk://#diff-912c4f60653cc2c8d00fda0b21a7a65ab1c3e1c3f65007e1f211f40c951596b8R31-R34) [[5]](diffhunk://#diff-912c4f60653cc2c8d00fda0b21a7a65ab1c3e1c3f65007e1f211f40c951596b8R48-L51) [[6]](diffhunk://#diff-912c4f60653cc2c8d00fda0b21a7a65ab1c3e1c3f65007e1f211f40c951596b8R93)…ioning a day before he leaves cllg for home on 13th Feb